### PR TITLE
Mock out sqs.config.credentials.* so that tests can run

### DIFF
--- a/test/Queue.test.ts
+++ b/test/Queue.test.ts
@@ -53,6 +53,12 @@ describe(`Queue`, () => {
   beforeEach(async () => {
     clearMocks();
     sqs = new AWS.SQS();
+    sqs.config = {
+      credentials: {
+        accessKeyId: 'FAKE-ACCESS-KEY',
+        secretAccessKey: 'FAKE-SECRET-KEY',
+      },
+    };
     params = {
       queueName,
       handler: jest.fn(),


### PR DESCRIPTION
The mocks don't pick up the shared AWS `config`, and we want to be careful not to include live AWS credentials during unit testing anyway (just in case it does end up hitting the underlying API)