### PR TITLE
Fix how queue names are validated when injecting the fifo suffix

### DIFF
--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -96,12 +96,13 @@ export default class Queue implements QueueConfig {
   public deleteImmediately: boolean;
 
   constructor(config: QueueConfig) {
-    utils.validateQueueName(config.queueName);
     // If this is a FIFO queue and the provided queue name
     // doesn't end with `.fifo`, append it now.
     if (config.fifo && !utils.isFifoQueueName(config.queueName)) {
       config.queueName = config.queueName + '.fifo';
     }
+    utils.validateQueueName(config.queueName);
+
     _.defaults(this, config, {
       sqs: new AWS.SQS(),
       fifo: DEFAULTS.FIFO,

--- a/test/Queue.test.ts
+++ b/test/Queue.test.ts
@@ -64,6 +64,19 @@ describe(`Queue`, () => {
     await queue.create();
   });
 
+  describe(`constructor`, () => {
+    it(`validates the name, even when injecting the .fifo suffix`, () => {
+      expect(() => {
+        new Queue({
+          ...params,
+          fifo: true,
+          queueName:
+            'a-queue-name-with-79-chars-that-exceeds-the-limit-when-the-fifo-suffix-is-added',
+        });
+      }).toThrow(/characters/i);
+    });
+  });
+
   describe(`create`, () => {
     it(`creates a queue with the provided name`, () => {
       expect(queue.queueUrl).toBe(queueUrl);


### PR DESCRIPTION
Previously, we would have let queue names through that would have triggered a less helpful error way down the line by SQS